### PR TITLE
Update scalafmt to 3.3.3

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# Don't edit this file!
+# It is automatically updated after every release of https://github.com/alejandrohdezma/sbt-ci
+# If you want to suggest a change, please open a PR or issue in that repository
+ko_fi: alejandrohdezma

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,10 @@ jobs:
           token: ${{ secrets.GH_APP_TOKEN }}
 
       - name: Checkout project
-        uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 # v2.3.5
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
         with:
           token: ${{ steps.github_app.outputs.token }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Enable auto-merge for this PR
         run: gh pr merge --auto --merge ${{github.event.pull_request.number}}
@@ -73,7 +74,7 @@ jobs:
       - name: Commit changes by `sbt generateCiFiles`
         uses: alejandrohdezma/actions/commit-and-push@v1
         with:
-          message: Run `sbt generateCiFiles`
+          message: Run `sbt generateCiFiles` [skip ci]
 
       - name: Run `sbt fix`
         uses: alejandrohdezma/actions/scala@v1
@@ -84,7 +85,7 @@ jobs:
       - name: Commit changes by `sbt fix`
         uses: alejandrohdezma/actions/commit-and-push@v1
         with:
-          message: Run `sbt fix`
+          message: Run `sbt fix` [skip ci]
 
   test:
     needs: [labeler, ci-steward]
@@ -103,7 +104,7 @@ jobs:
           - openjdk:1.17
     steps:
       - name: Checkout project
-        uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 # v2.3.5
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 # v2.3.5
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
         with:
           fetch-depth: 0
 
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 # v2.3.5
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
         with:
           fetch-depth: 0
           ref: main

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -6,6 +6,11 @@
 
 version = 3.3.3
 
+# This value is automatically set based on your current `ThisBuild / scalaVersion` setting.
+# `scala212source3`/`scala213source3` will be set if `scalaVersion` is set to any of those versions
+#  and `-Xsource:3` option is present under `ThisBuild / scalacOptions`.
+runner.dialect = scala212
+
 # Number of maximum characters in a column
 maxColumn = 120
 

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,7 +4,7 @@
 # To edit the original configurations go to
 # https://github.com/alejandrohdezma/sbt-scalafmt-defaults/edit/master/.scalafmt.conf
 
-version = 3.0.6
+version = 3.3.3
 
 # Number of maximum characters in a column
 maxColumn = 120

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,5 @@
 # @DESCRIPTION@
 
-[![][github-action-badge]][github-action] [![][maven-badge]][maven] [![][steward-badge]][steward]
-
 ## Installation
 
 Add the following line to your `plugins.sbt` file:
@@ -22,13 +20,12 @@ The included plugin is automatically activated. It will enable `scalafmtOnCompil
 
 > You can add the `.scalafmt.conf` file to the repository's `.gitignore`, since it's going to be automatically re-created on every build.
 
+## Runner-dialect
+
+Since v3.1.0, [the Scalafmt `runner.dialect` option is mandatory](https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects). This plugin automatically sets this option based on your current `ThisBuild / scalaVersion` setting. The `scala212source3`/`scala213source3` will be set if `scalaVersion` is set to those and `-Xsource:3` option is present under `ThisBuild / scalacOptions`.
+
+If for any reason you want to alter the generated dialect or specify the `runner.dialect` for a subset of files using `fileOverride` you can use the [`.scalafmt-extra.conf` file](#extra-configurations).
+
 ### Extra configurations
 
 Extra configurations can be added to a file named `.scalafmt-extra.conf` at the root of your repository. The content of this file will be automatically appended to the auto-generated `.scalafmt.conf`.
-
-[github-action]: https://github.com/alejandrohdezma/sbt-scalafmt-defaults/actions
-[github-action-badge]: https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Falejandrohdezma%2Fsbt-scalafmt-defaults%2Fbadge%3Fref%3Dmaster&style=flat
-[maven]: https://search.maven.org/search?q=g:%20com.alejandrohdezma%20AND%20a:sbt-scalafmt-defaults
-[maven-badge]: https://maven-badges.herokuapp.com/maven-central/com.alejandrohdezma/sbt-scalafmt-defaults/badge.svg?kill_cache=1
-[steward]: https://scala-steward.org
-[steward-badge]: https://img.shields.io/badge/Scala_Steward-helping-brightgreen.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala211/build.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala211/build.sbt
@@ -1,0 +1,9 @@
+ThisBuild / scalaVersion := "2.11.12"
+
+TaskKey[Unit]("checkScalafmtConfFile") := {
+  val expected = sys
+    .props("scalafmt.conf.content")
+    .replace("runner.dialect = scala212", "runner.dialect = scala211")
+
+  assert(IO.read(file(".scalafmt.conf")) == expected)
+}

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala211/project/build.properties
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala211/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.1

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala211/project/plugins.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala211/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.alejandrohdezma" % "sbt-scalafmt-defaults" % sys.props("plugin.version"))
+addSbtPlugin("org.scalameta"       % "sbt-scalafmt"          % "2.4.6")

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala211/test
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala211/test
@@ -1,0 +1,3 @@
+# this test ensures the .scalafmt.conf is generated with the correct dialect
+> scalafmt
+> checkScalafmtConfFile

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212/build.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212/build.sbt
@@ -1,0 +1,9 @@
+ThisBuild / scalaVersion := "2.12.15"
+
+TaskKey[Unit]("checkScalafmtConfFile") := {
+  val expected = sys
+    .props("scalafmt.conf.content")
+    .replace("runner.dialect = scala212", "runner.dialect = scala212")
+
+  assert(IO.read(file(".scalafmt.conf")) == expected)
+}

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212/project/build.properties
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.1

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212/project/plugins.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.alejandrohdezma" % "sbt-scalafmt-defaults" % sys.props("plugin.version"))
+addSbtPlugin("org.scalameta"       % "sbt-scalafmt"          % "2.4.6")

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212/test
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212/test
@@ -1,0 +1,3 @@
+# this test ensures the .scalafmt.conf is generated with the correct dialect
+> scalafmt
+> checkScalafmtConfFile

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212source3/build.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212source3/build.sbt
@@ -1,0 +1,10 @@
+ThisBuild / scalaVersion  := "2.12.15"
+ThisBuild / scalacOptions += "-Xsource:3"
+
+TaskKey[Unit]("checkScalafmtConfFile") := {
+  val expected = sys
+    .props("scalafmt.conf.content")
+    .replace("runner.dialect = scala212", "runner.dialect = scala212source3")
+
+  assert(IO.read(file(".scalafmt.conf")) == expected)
+}

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212source3/project/build.properties
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212source3/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.1

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212source3/project/plugins.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212source3/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.alejandrohdezma" % "sbt-scalafmt-defaults" % sys.props("plugin.version"))
+addSbtPlugin("org.scalameta"       % "sbt-scalafmt"          % "2.4.6")

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212source3/test
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala212source3/test
@@ -1,0 +1,3 @@
+# this test ensures the .scalafmt.conf is generated with the correct dialect
+> scalafmt
+> checkScalafmtConfFile

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213/build.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213/build.sbt
@@ -1,0 +1,9 @@
+ThisBuild / scalaVersion := "2.13.8"
+
+TaskKey[Unit]("checkScalafmtConfFile") := {
+  val expected = sys
+    .props("scalafmt.conf.content")
+    .replace("runner.dialect = scala212", "runner.dialect = scala213")
+
+  assert(IO.read(file(".scalafmt.conf")) == expected)
+}

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213/project/build.properties
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.1

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213/project/plugins.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.alejandrohdezma" % "sbt-scalafmt-defaults" % sys.props("plugin.version"))
+addSbtPlugin("org.scalameta"       % "sbt-scalafmt"          % "2.4.6")

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213/test
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213/test
@@ -1,0 +1,3 @@
+# this test ensures the .scalafmt.conf is generated with the correct dialect
+> scalafmt
+> checkScalafmtConfFile

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3/build.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3/build.sbt
@@ -1,0 +1,10 @@
+ThisBuild / scalaVersion  := "2.13.8"
+ThisBuild / scalacOptions += "-Xsource:3"
+
+TaskKey[Unit]("checkScalafmtConfFile") := {
+  val expected = sys
+    .props("scalafmt.conf.content")
+    .replace("runner.dialect = scala212", "runner.dialect = scala213source3")
+
+  assert(IO.read(file(".scalafmt.conf")) == expected)
+}

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3/project/build.properties
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.1

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3/project/plugins.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.alejandrohdezma" % "sbt-scalafmt-defaults" % sys.props("plugin.version"))
+addSbtPlugin("org.scalameta"       % "sbt-scalafmt"          % "2.4.6")

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3/test
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3/test
@@ -1,0 +1,3 @@
+# this test ensures the .scalafmt.conf is generated with the correct dialect
+> scalafmt
+> checkScalafmtConfFile

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala3/build.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala3/build.sbt
@@ -1,0 +1,9 @@
+ThisBuild / scalaVersion := "3.1.0"
+
+TaskKey[Unit]("checkScalafmtConfFile") := {
+  val expected = sys
+    .props("scalafmt.conf.content")
+    .replace("runner.dialect = scala212", "runner.dialect = scala3")
+
+  assert(IO.read(file(".scalafmt.conf")) == expected)
+}

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala3/project/build.properties
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala3/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.1

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala3/project/plugins.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala3/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.alejandrohdezma" % "sbt-scalafmt-defaults" % sys.props("plugin.version"))
+addSbtPlugin("org.scalameta"       % "sbt-scalafmt"          % "2.4.6")

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala3/test
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala3/test
@@ -1,0 +1,3 @@
+# this test ensures the .scalafmt.conf is generated with the correct dialect
+> scalafmt
+> checkScalafmtConfFile


### PR DESCRIPTION
# What has been done in this PR?

- Update scalafmt to 3.3.3
- Ensure `runner.dialect` (mandatory since 3.1.0) is set correctly in `.scalafmt.conf`.