### PR TITLE
Stop setting `scalafmtOnCompile` to `true`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ addSbtPlugin("com.alejandrohdezma" % "sbt-scalafmt-defaults" % "@VERSION@")
 
 ## Usage
 
-The included plugin is automatically activated. It will enable `scalafmtOnCompile` by default (except when running on CI) and will create a `.scalafmt.conf` in your project's root folder with the following content:
+The included plugin is automatically activated. It will create a `.scalafmt.conf` in your project's root folder with the following content:
 
 ```hocon
 @SCALAFMT_CONF@

--- a/modules/sbt-scalafmt-defaults/src/main/scala/com/alejandrohdezma/sbt/scalafmt/defaults/SbtScalafmtDefaults.scala
+++ b/modules/sbt-scalafmt-defaults/src/main/scala/com/alejandrohdezma/sbt/scalafmt/defaults/SbtScalafmtDefaults.scala
@@ -30,9 +30,6 @@ object SbtScalafmtDefaults extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  override def globalSettings: Seq[Def.Setting[_]] =
-    Seq(scalafmtOnCompile := !sys.env.contains("CI"))
-
   @SuppressWarnings(Array("scalafix:Disable.blocking.io", "scalafix:DisableSyntax.=="))
   override def buildSettings: Seq[Setting[_]] = Seq(
     scalafmtConfig := {


### PR DESCRIPTION
Most IDEs already run format on your code on saving so this setting just makes everything slower in most cases