### PR TITLE
Improve scalafmt dialect detection

### DIFF
--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -22,7 +22,7 @@ The included plugin is automatically activated. It will create a `.scalafmt.conf
 
 ## Runner-dialect
 
-Since v3.1.0, [the Scalafmt `runner.dialect` option is mandatory](https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects). This plugin automatically sets this option based on your current `ThisBuild / scalaVersion` setting. The `scala212source3`/`scala213source3` will be set if `scalaVersion` is set to those and `-Xsource:3` option is present under `ThisBuild / scalacOptions`.
+Since v3.1.0, [the Scalafmt `runner.dialect` option is mandatory](https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects). This plugin automatically sets this option based on your current `ThisBuild / scalaVersion` setting. For Scala 3, version-specific dialects are used (e.g., `scala33` for Scala 3.3.x). The `scala212source3`/`scala213source3` will be set if `scalaVersion` is set to those and any `-Xsource:3` variant (like `-Xsource:3-cross`) is present under `ThisBuild / scalacOptions`.
 
 If for any reason you want to alter the generated dialect or specify the `runner.dialect` for a subset of files using `fileOverride` you can use the [`.scalafmt-extra.conf` file](#extra-configurations).
 

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -8,7 +8,7 @@ version = "3.10.7"
 
 # This value is automatically set based on your current `ThisBuild / scalaVersion` setting.
 # `scala212source3`/`scala213source3` will be set if `scalaVersion` is set to any of those versions
-#  and `-Xsource:3` option is present under `ThisBuild / scalacOptions`.
+#  and any `-Xsource:3` variant option is present under `ThisBuild / scalacOptions`.
 runner.dialect = scala212
 
 # Number of maximum characters in a column

--- a/modules/sbt-scalafmt-defaults/src/main/scala/com/alejandrohdezma/sbt/scalafmt/defaults/SbtScalafmtDefaults.scala
+++ b/modules/sbt-scalafmt-defaults/src/main/scala/com/alejandrohdezma/sbt/scalafmt/defaults/SbtScalafmtDefaults.scala
@@ -33,7 +33,7 @@ object SbtScalafmtDefaults extends AutoPlugin {
   @SuppressWarnings(Array("scalafix:Disable.blocking.io", "scalafix:DisableSyntax.=="))
   override def buildSettings: Seq[Setting[_]] = Seq(
     scalafmtConfig := {
-      val xSource3 = scalacOptions.value.seq.exists(_ == "-Xsource:3")
+      val xSource3 = scalacOptions.value.seq.exists(_.startsWith("-Xsource:3"))
 
       val dialect = scalaVersion.value match {
         case v if v.startsWith("2.11")             => "scala211"
@@ -41,6 +41,13 @@ object SbtScalafmtDefaults extends AutoPlugin {
         case v if v.startsWith("2.12")             => "scala212"
         case v if v.startsWith("2.13") && xSource3 => "scala213source3"
         case v if v.startsWith("2.13")             => "scala213"
+        case v if v.startsWith("3.0")              => "scala30"
+        case v if v.startsWith("3.1")              => "scala31"
+        case v if v.startsWith("3.2")              => "scala32"
+        case v if v.startsWith("3.3")              => "scala33"
+        case v if v.startsWith("3.4")              => "scala34"
+        case v if v.startsWith("3.5")              => "scala35"
+        case v if v.startsWith("3.6")              => "scala36"
         case v if v.startsWith("3")                => "scala3"
       }
 

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3-cross/build.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3-cross/build.sbt
@@ -1,11 +1,12 @@
-ThisBuild / scalaVersion := "3.99.0"
+ThisBuild / scalaVersion  := "2.13.8"
+ThisBuild / scalacOptions += "-Xsource:3-cross"
 
 munitSuites += "ScriptedSuite" -> new FunSuite {
 
   test("Files match") {
     val expected = sys
       .props("scalafmt.conf.content")
-      .replace("runner.dialect = scala212", "runner.dialect = scala3")
+      .replace("runner.dialect = scala212", "runner.dialect = scala213source3")
 
     assertNoDiff(IO.read(file(".scalafmt.conf")), expected)
   }

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3-cross/project/build.properties
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3-cross/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.8

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3-cross/project/plugins.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3-cross/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.alejandrohdezma" % "sbt-scalafmt-defaults" % sys.props("plugin.version"))
+addSbtPlugin("org.scalameta"       % "sbt-scalafmt"          % "2.5.6")
+addSbtPlugin("com.alejandrohdezma" % "sbt-scripted-munit"    % "0.1.0")

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3-cross/test
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala213source3-cross/test
@@ -1,0 +1,3 @@
+# this test ensures the .scalafmt.conf is generated with the correct dialect
+> scalafmt
+> munitScripted

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala33/build.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala33/build.sbt
@@ -1,11 +1,11 @@
-ThisBuild / scalaVersion := "3.99.0"
+ThisBuild / scalaVersion := "3.3.0"
 
 munitSuites += "ScriptedSuite" -> new FunSuite {
 
   test("Files match") {
     val expected = sys
       .props("scalafmt.conf.content")
-      .replace("runner.dialect = scala212", "runner.dialect = scala3")
+      .replace("runner.dialect = scala212", "runner.dialect = scala33")
 
     assertNoDiff(IO.read(file(".scalafmt.conf")), expected)
   }

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala33/project/build.properties
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala33/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.8

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala33/project/plugins.sbt
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala33/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.alejandrohdezma" % "sbt-scalafmt-defaults" % sys.props("plugin.version"))
+addSbtPlugin("org.scalameta"       % "sbt-scalafmt"          % "2.5.6")
+addSbtPlugin("com.alejandrohdezma" % "sbt-scripted-munit"    % "0.1.0")

--- a/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala33/test
+++ b/modules/sbt-scalafmt-defaults/src/sbt-test/sbt-scalafmt-defaults/runner-dialect-scala33/test
@@ -1,0 +1,3 @@
+# this test ensures the .scalafmt.conf is generated with the correct dialect
+> scalafmt
+> munitScripted


### PR DESCRIPTION
## :computer: How to review this PR?

This PR was created with the idea of being reviewed commit by commit. Each commit contains an incremental change that makes it easier to review. Also some of the commits contain additional information in their description to help understand why the change was made.

<details><summary><b>I also recommend checking "Hide whitespace" when reviewing this PR!</b></summary></br>


![](https://i0.wp.com/user-images.githubusercontent.com/2503052/137387087-91cc8458-9e11-44a9-8da0-f48251ec452c.gif?ssl=1)

</details>

## :rocket: What's included in this PR?

## Summary

- Detect all `-Xsource:3` variants (including `-Xsource:3-cross`) by using `startsWith("-Xsource:3")` instead of exact equality against `"-Xsource:3"`
- Map Scala 3.x versions to version-specific scalafmt dialects (`scala30` through `scala36`) instead of the generic `scala3`, with `scala3` kept as fallback for unknown minor versions
- Add scripted tests for `-Xsource:3-cross` detection and `scala33` dialect mapping
- Update README documentation to reflect both changes